### PR TITLE
Add PageMeta.svelte for per-page unfurl previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ shared and stable:
 | `sveltekitbook/md` | `md(text, { glossary, glossaryBase })` — inline `**bold**`, `*em*`, `[[term]]` → glossary link. |
 | `sveltekitbook/palette` | `makeSpectrum({ ramp, inverted })` → `{ paletteFor, styleFor, modeFor }` for spectrum books. |
 | `sveltekitbook/Giscus.svelte` | Giscus comments mounted by props (`repo`, `repoId`, `category`, `categoryId`, `term`, `mode`). |
+| `sveltekitbook/PageMeta.svelte` | Drops Open Graph + Twitter Card tags into `<svelte:head>` so per-page URLs unfurl with a tldr in Slack/iMessage/Discord. Props: `title`, `description`, `url`, `siteName`, `image`, `imageAlt`, `type`, `twitterCard`. |
 
 Consumed directly by projects generated via `npm create sveltekitbook`.
 You usually don't install it by hand.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "./gestures": "./src/gestures.js",
     "./md": "./src/md.js",
     "./palette": "./src/palette.js",
-    "./Giscus.svelte": "./src/Giscus.svelte"
+    "./Giscus.svelte": "./src/Giscus.svelte",
+    "./PageMeta.svelte": "./src/PageMeta.svelte"
   },
   "peerDependencies": {
     "svelte": "^5.0.0"

--- a/src/PageMeta.svelte
+++ b/src/PageMeta.svelte
@@ -1,0 +1,83 @@
+<script>
+  /**
+   * Emits Open Graph + Twitter Card meta tags so that pasting a page URL
+   * into Slack, iMessage, Discord, etc. unfurls with the page title and
+   * a tldr/description preview.
+   *
+   * Drop into a page's <svelte:head>:
+   *
+   *   <PageMeta
+   *     title={section.title}
+   *     description={section.tldr}
+   *     url={canonical}
+   *     siteName={TITLE}
+   *   />
+   *
+   * Pages prerender to static HTML, so the tags land in the prerendered
+   * <head> of each route — exactly what link-unfurlers fetch.
+   *
+   * Props:
+   *   title       — page title (required for a usable preview)
+   *   description — the tldr; also rendered as <meta name="description">
+   *   url         — canonical page URL (used for og:url; recommended)
+   *   siteName    — book title (og:site_name)
+   *   image       — absolute URL to a preview image; flips Twitter card
+   *                 to summary_large_image when present
+   *   imageAlt    — alt text for the preview image
+   *   type        — og:type, defaults to 'article'
+   *   twitterCard — override the Twitter card type
+   */
+  let {
+    title,
+    description,
+    url,
+    siteName,
+    image,
+    imageAlt,
+    type = 'article',
+    twitterCard
+  } = $props();
+
+  let card = $derived(twitterCard ?? (image ? 'summary_large_image' : 'summary'));
+</script>
+
+<svelte:head>
+  {#if description}
+    <meta name="description" content={description} />
+  {/if}
+
+  {#if title}
+    <meta property="og:title" content={title} />
+  {/if}
+  {#if description}
+    <meta property="og:description" content={description} />
+  {/if}
+  {#if url}
+    <meta property="og:url" content={url} />
+    <link rel="canonical" href={url} />
+  {/if}
+  {#if siteName}
+    <meta property="og:site_name" content={siteName} />
+  {/if}
+  <meta property="og:type" content={type} />
+  {#if image}
+    <meta property="og:image" content={image} />
+    {#if imageAlt}
+      <meta property="og:image:alt" content={imageAlt} />
+    {/if}
+  {/if}
+
+  <meta name="twitter:card" content={card} />
+  {#if title}
+    <meta name="twitter:title" content={title} />
+  {/if}
+  {#if description}
+    <meta name="twitter:description" content={description} />
+  {/if}
+  {#if image}
+    <meta name="twitter:image" content={image} />
+    {#if imageAlt}
+      <meta name="twitter:image:alt" content={imageAlt} />
+    {/if}
+  {/if}
+</svelte:head>


### PR DESCRIPTION
## Summary
- New `sveltekitbook/PageMeta.svelte` export — emits Open Graph + Twitter Card meta tags into `<svelte:head>` from per-page `title` and `description` (the tldr) props.
- When a book consumer adds a `tldr` field to a section in `outline.js` and drops `<PageMeta>` into the `[slug]` page, pasting that page's URL into Slack / iMessage / Discord unfurls with a real preview instead of just the bare URL.
- Pages already prerender to static HTML, so the tags land in the prerendered `<head>` of every route — exactly what unfurlers fetch.

## Usage
```svelte
<script>
  import PageMeta from 'sveltekitbook/PageMeta.svelte';
  import { TITLE } from '$lib/config.js';
  let { data } = \$props();
  let section = \$derived(data.section);
</script>

<PageMeta
  title={section.title}
  description={section.tldr}
  url={\`https://example.com/\${section.num}\`}
  siteName={TITLE}
/>
```

Optional props: `image`, `imageAlt`, `type` (defaults to `article`), `twitterCard` (defaults to `summary`, or `summary_large_image` when an image is provided).

## Test plan
- [ ] Import `sveltekitbook/PageMeta.svelte` from a downstream book and verify the prerendered HTML contains `og:title`, `og:description`, `og:url`, `og:site_name`, `og:type`, `twitter:card`, `twitter:title`, `twitter:description`.
- [ ] Paste a deployed page URL into Slack and confirm it unfurls with the tldr.
- [ ] Verify `summary_large_image` flips on when `image` is set.
- [ ] Confirm consumers without a `tldr` field render the page unchanged (component is purely additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)