### PR TITLE
Add mdBlock paragraph-aware markdown helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.0] — 2026-05-01
+
+### Added
+- `mdBlock(text, opts)` exported from `sveltekitbook/md` — paragraph-aware
+  block renderer. Splits trusted markdown text on blank lines and emits
+  one `<p>` per paragraph with `md()` applied for inline transforms. Use
+  this for any field that may contain multiple paragraphs (section bodies,
+  ELI5 blocks, chapter intros) and render the result inside a `<div>`
+  wrapper — never inside a `<p>`, which collapses paragraphs into one block.
+
 ## [0.2.0] — 2026-04-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ shared and stable:
 | Export | What it is |
 | ------ | ---------- |
 | `sveltekitbook/gestures` | `createPager({ onNext, onPrev, setOffset })` — wheel + touch-drag → page nav. |
-| `sveltekitbook/md` | `md(text, { glossary, glossaryBase })` — inline `**bold**`, `*em*`, `[[term]]` → glossary link. |
+| `sveltekitbook/md` | `md(text, { glossary, glossaryBase })` — inline `**bold**`, `*em*`, `[[term]]` → glossary link. Also exports `mdBlock(text, opts)` — paragraph-aware variant that splits on blank lines and emits `<p>` per paragraph. Render inside a `<div>` wrapper, never `<p>`. |
 | `sveltekitbook/palette` | `makeSpectrum({ ramp, inverted })` → `{ paletteFor, styleFor, modeFor }` for spectrum books. |
 | `sveltekitbook/Giscus.svelte` | Giscus comments mounted by props (`repo`, `repoId`, `category`, `categoryId`, `term`, `mode`). |
 | `sveltekitbook/PageMeta.svelte` | Drops Open Graph + Twitter Card tags into `<svelte:head>` so per-page URLs unfurl with a tldr in Slack/iMessage/Discord. Props: `title`, `description`, `url`, `siteName`, `image`, `imageAlt`, `type`, `twitterCard`. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sveltekitbook",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Runtime helpers for SvelteKit books scaffolded by create-sveltekitbook.",
   "type": "module",
   "author": "Andrew Gauger",

--- a/src/md.js
+++ b/src/md.js
@@ -64,4 +64,29 @@ export function md(text, opts = {}) {
   return out;
 }
 
+/**
+ * Render trusted block-level markdown — paragraphs only.
+ *
+ * Splits `text` on blank lines (one or more `\n\n`) and emits one `<p>` per
+ * paragraph, with inline transforms (`md`) applied per paragraph. Use this
+ * for any field that may contain multiple paragraphs (section bodies, ELI5
+ * blocks, chapter intros) and render the result inside a `<div>` wrapper.
+ *
+ * Do NOT wrap the output in a `<p>` — that produces nested `<p>` tags, which
+ * the browser auto-closes, collapsing every paragraph into one block.
+ *
+ * @param {string} text
+ * @param {{ glossary?: Record<string, unknown>, glossaryBase?: string }} [opts]
+ * @returns {string} HTML string of `<p>...</p>` paragraphs joined together.
+ */
+export function mdBlock(text, opts = {}) {
+  if (!text) return '';
+  return String(text)
+    .split(/\n{2,}/)
+    .map((p) => p.trim())
+    .filter(Boolean)
+    .map((p) => `<p>${md(p, opts)}</p>`)
+    .join('');
+}
+
 export { slug };


### PR DESCRIPTION
## Summary
- Adds `mdBlock(text, opts)` to `sveltekitbook/md` — splits trusted markdown on blank lines and emits one `<p>` per paragraph with `md()` applied for inline transforms.
- Bumps to 0.3.0 and updates README + CHANGELOG.

## Why
Books scaffolded by `create-sveltekitbook` wrap the section body in a single `<p class="body-text">` and inject `md(section.body)` inside it. `md()` is inline-only — it does not turn `\n\n` into `<p>` tags — so any field with multi-paragraph source (section bodies, ELI5 blocks, chapter intros) renders as one collapsed wall of text. Worse, when authors do escape into block-level markdown elsewhere, nesting `<p>` inside `<p>` causes the browser to auto-close the outer `<p>` and silently fragment the layout.

`mdBlock` is the supported way to render multi-paragraph trusted markdown: split on blank lines, wrap each paragraph in `<p>`, apply `md()` for inline transforms. Consumers render the result inside a `<div>` wrapper (CSS targets `:global(p)` for typography and margin).

A follow-up PR in `create-sveltekitbook` updates the four scaffold templates (chaptered, timeline, spectrum, none) to use `mdBlock` and `<div>` wrappers.

## Test plan
- [x] Smoke-test the export with single paragraph, multi-paragraph, empty, undefined, triple-newline, and inline-link inputs — all produce the expected `<p>...</p>` output.
- [ ] Reviewer: verify CHANGELOG and README entries are accurate.
- [ ] Once merged + published, confirm `create-sveltekitbook` PR pulls `^0.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)