### PR TITLE
Render backtick code spans in md/mdBlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- `md()` and `mdBlock()` now render backtick code spans —
+  `` `code` `` becomes `<code>code</code>`. Code spans are pulled
+  out to placeholders before other transforms run, so their
+  contents render literally (CommonMark behavior — `` `**not
+  bold**` `` stays as `**not bold**` inside `<code>`, links and
+  glossary syntax inside backticks are left alone). HTML chars
+  inside code spans are still escaped.
+
 ## [0.3.0] — 2026-05-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ shared and stable:
 | Export | What it is |
 | ------ | ---------- |
 | `sveltekitbook/gestures` | `createPager({ onNext, onPrev, setOffset })` — wheel + touch-drag → page nav. |
-| `sveltekitbook/md` | `md(text, { glossary, glossaryBase })` — inline `**bold**`, `*em*`, `[[term]]` → glossary link. Also exports `mdBlock(text, opts)` — paragraph-aware variant that splits on blank lines and emits `<p>` per paragraph. Render inside a `<div>` wrapper, never `<p>`. |
+| `sveltekitbook/md` | `md(text, { glossary, glossaryBase })` — inline `` `code` ``, `**bold**`, `*em*`, `[text](url)`, `[[term]]` → glossary link. Also exports `mdBlock(text, opts)` — paragraph-aware variant that splits on blank lines and emits `<p>` per paragraph. Render inside a `<div>` wrapper, never `<p>`. |
 | `sveltekitbook/palette` | `makeSpectrum({ ramp, inverted })` → `{ paletteFor, styleFor, modeFor }` for spectrum books. |
 | `sveltekitbook/Giscus.svelte` | Giscus comments mounted by props (`repo`, `repoId`, `category`, `categoryId`, `term`, `mode`). |
 | `sveltekitbook/PageMeta.svelte` | Drops Open Graph + Twitter Card tags into `<svelte:head>` so per-page URLs unfurl with a tldr in Slack/iMessage/Discord. Props: `title`, `description`, `url`, `siteName`, `image`, `imageAlt`, `type`, `twitterCard`. |

--- a/src/md.js
+++ b/src/md.js
@@ -1,11 +1,15 @@
 // Inline markdown for trusted (hardcoded) text.
+//   `code`         → <code>
 //   **bold**       → <strong>
 //   *em*           → <em>
 //   [text](url)    → <a href="url">text</a>  (http/https/mailto/relative only)
 //   [[term]]       → <a href="{glossaryBase}#term-slug">term</a>  (when glossary is enabled)
 //
-// Order matters: bold/em first, then external links, then glossary linking,
-// so that hrefs aren't escaped and `[[term]]` can't collide with `[t](u)`.
+// Order matters: code spans are pulled out to placeholders first so their
+// contents don't get re-processed (CommonMark — code spans are literal),
+// then bold/em, then external links, then glossary linking, so hrefs aren't
+// escaped and `[[term]]` can't collide with `[t](u)`. Code spans are
+// substituted back at the end wrapped in `<code>`.
 
 const ESCAPE = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
 const escape = (s) => String(s).replace(/[&<>"']/g, (c) => ESCAPE[c]);
@@ -31,7 +35,13 @@ export function md(text, opts = {}) {
   const glossary = opts.glossary;
   const glossaryBase = opts.glossaryBase ?? '/glossary';
 
-  let out = escape(text)
+  const codeSpans = [];
+  let out = escape(text).replace(/`([^`]+)`/g, (_, content) => {
+    codeSpans.push(content);
+    return `\x00CODE${codeSpans.length - 1}\x00`;
+  });
+
+  out = out
     .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
     .replace(/(^|[^*])\*([^*]+)\*/g, '$1<em>$2</em>');
 
@@ -60,6 +70,8 @@ export function md(text, opts = {}) {
     // Strip [[ ]] if no glossary so the syntax never leaks through.
     out = out.replace(/\[\[([^\]]+)\]\]/g, '$1');
   }
+
+  out = out.replace(/\x00CODE(\d+)\x00/g, (_, i) => `<code>${codeSpans[+i]}</code>`);
 
   return out;
 }


### PR DESCRIPTION
## Summary

\`md()\` and \`mdBlock()\` now render inline backtick code spans — \`\` \`code\` \`\` becomes \`<code>code</code>\`. Code spans are pulled out to placeholders before bold/em/link/glossary regexes run, then substituted back at the end, so their contents stay literal (CommonMark behavior). HTML chars inside code are still escaped.

## Why

Without this, scaffolded books accumulate prose like \`Each page is a plain object — \\\`title\\\`, \\\`hook\\\`, \\\`body\\\`...\` and render the backticks as literal characters. Books that talk about code (\`sveltekitbook-tour\`, \`too-many-lists\`) hit this on most pages.

## Tested round-trips

- \`\\\`code\\\`\` → \`<code>code</code>\`
- multiple spans on one line → each wraps independently
- code containing \`**bold**\` / \`[a](b)\` / \`[[term]]\` → all stay literal
- code containing \`< > & " '\` → escape correctly
- mismatched single backtick → passes through unchanged

## Note

This is the runtime piece. Consumers also want \`code\` styling — covered in [create-sveltekitbook#7](https://github.com/AndyGauge/create-sveltekitbook/pull/7) (scaffolded \`app.css\`) and the \`sveltekitbook-tour\` contents PR ([#3](https://github.com/AndyGauge/sveltekitbook-tour/pull/3)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)